### PR TITLE
Allow other units for width and height

### DIFF
--- a/src/components/SlideoutPanel/index.vue
+++ b/src/components/SlideoutPanel/index.vue
@@ -107,7 +107,7 @@ const vm = {
 
         if (!panel.height) {
           panel.styles.height = '900px';
-        } else if (!panel.height.endsWith || !panel.height.endsWith('px')) {
+        } else if (!isNaN(panel.height)) {
           panel.styles.height = `${panel.height}px`;
         } else {
           panel.styles.height = panel.height;
@@ -117,7 +117,7 @@ const vm = {
 
         if (!panel.width) {
           panel.styles.width = '900px';
-        } else if (!panel.width.endsWith || !panel.width.endsWith('px')) {
+        } else if (!isNaN(panel.width)) {
           panel.styles.width = `${panel.width}px`;
         } else {
           panel.styles.width = panel.width;

--- a/src/components/SlideoutPanel/index.vue
+++ b/src/components/SlideoutPanel/index.vue
@@ -107,7 +107,7 @@ const vm = {
 
         if (!panel.height) {
           panel.styles.height = '900px';
-        } else if (!isNaN(panel.height)) {
+        } else if (/^[0-9.]+$/gius.test(panel.height)) {
           panel.styles.height = `${panel.height}px`;
         } else {
           panel.styles.height = panel.height;
@@ -117,7 +117,7 @@ const vm = {
 
         if (!panel.width) {
           panel.styles.width = '900px';
-        } else if (!isNaN(panel.width)) {
+        } else if (/^[0-9.]+$/gius.test(panel.width)) {
           panel.styles.width = `${panel.width}px`;
         } else {
           panel.styles.width = panel.width;


### PR DESCRIPTION
Related to #37 

Updates conditional to check for a numeric panel height/width and if that's the case append `'px'`

Previously if `width: '50%'` were used we would end up with a width of `'50%px'`

Thanks a lot for this component, it's great!